### PR TITLE
A conditional statement ensures that the code is executed only when the selected button element has a class of 'history-btn'

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -186,16 +186,21 @@ historyBoxEl.click(function (event) {
     const searchHistory = JSON.parse(localStorage.getItem('searchHistory') || '[]');
     
     let chosenButtonTextContent = event.target.textContent;
-    console.log(chosenButtonTextContent);
 
-    // the function determines the index of an object in the local storage 
-    // by using the selected button and the text content of its associated city name.
-    let cityIndex = searchHistory.findIndex(element => 
-        element.cityName === chosenButtonTextContent);
-    let cityLat = searchHistory[cityIndex].lat;
-    let cityLon = searchHistory[cityIndex].lon;
+    if (event.target.getAttribute('class') !== 'history-btn') {
+        return
+    } else {
+        console.log(chosenButtonTextContent);
+    
+        // the function determines the index of an object in the local storage 
+        // by using the selected button and the text content of its associated city name.
+        let cityIndex = searchHistory.findIndex(element => element.cityName === chosenButtonTextContent);
 
-    getCurrentWeather(cityLat, cityLon);
+        let cityLat = searchHistory[cityIndex].lat;
+        let cityLon = searchHistory[cityIndex].lon;
+    
+        getCurrentWeather(cityLat, cityLon);
+    }
 })
 
 displayHistorySearch()


### PR DESCRIPTION
A conditional statement has been added as a fix to ensure that the code is executed only when the selected button element has a class of 'history-btn' . The code will now check if the classList of the clicked button element contains the class 'history-btn', rather than checking its parent container. This fix ensures that the code is executed only for history button elements and not for any other element within their container.