### PR TITLE
Modal alert will be removed after user clicks 'dismiss' button.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -169,7 +169,7 @@ function modalMessage(problemType) {
     // Hides modal alert on click "dismiss" button
     modalCloseBtn.addEventListener('click', function() {
       
-        modalContainer.close()
+        modalContainer.remove()
     })
 }
 


### PR DESCRIPTION
To prevent the duplication of <dialog> elements with the same ID in HTML, the modal alert container will be eliminated from the HTML DOM instead of being converted into a hidden state. The fix includes `remove()` method instead of `close()`.