### PR TITLE
The state was removed from history buttons.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -222,7 +222,7 @@ const displayHistoryButtons = () => {
         historyBtn = $('<button>').attr('class', 'history-btn'
         ).data('cityLat', {
             lat: element.lat,
-        }).text(`${element.cityName}, ${element.state}, ${element.country}`
+        }).text(`${element.cityName}, ${element.country}`
         ).insertBefore($('#clear-btn')) ;
     });
 


### PR DESCRIPTION
The state was eliminated from the history buttons to prevent the inconsistency in button size caused by long city and/or state names, which would take up a second line and make the button thicker.