### PR TITLE
An if statemant has been modified to only retrieve objects with a day themed icons for the forecast weather.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -96,7 +96,6 @@ const getCurrentWeather = (newCityObj) => {
     fetch(`https://api.openweathermap.org/data/2.5/weather?lat=${newCityObj.lat}&lon=${newCityObj.lon}&units=imperial&appid=${openWeatherMapApi}`)
     .then(response => response.json())
     .then(data => {
-        console.log(data)
             
         displayCurrentWeather(data, newCityObj)
         getForecast(newCityObj.lat, newCityObj.lon)
@@ -141,9 +140,9 @@ const displayForecast = (forecastData) => {
 
     const afternoonData = [];
 
-    // for loop is used to extract objects for the upcoming five forecast days with a time of 3:00 PM. At the time when this app was developed, the openweathermap API provided icons with a night theme for forecasted weather occurring at or before 12:00 PM.
+    // for loop is used to extract objects for the upcoming five forecast days with a day themed icon
     forecastData.forEach(element => {       
-        if (dayjs(element.dt_txt).format('HH:mm:ss') === '15:00:00') {
+        if ((dayjs(element.dt_txt).format('HH:mm:ss') === '09:00:00' && element.sys.pod === 'd') || (dayjs(element.dt_txt).format('HH:mm:ss') === '21:00:00' && element.sys.pod === 'd')) {
             afternoonData.push(element);   
         }
     });


### PR DESCRIPTION
Before, the if statement checked for an object with a time of 15:00 to retrieve daytime information, but it was discovered that the time provided was based on my local time zone. As a result, in some countries, 15:00 could return forecasted weather icons for the night. To ensure that only icons with a daytime theme are provided for the forecast weather information, the updated if statement now checks for both the time and the 'd' part of the day.